### PR TITLE
normalize REST dsl usage

### DIFF
--- a/camel/services/basic-image-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/camel/services/basic-image-service/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,40 +22,46 @@
     <routeContextRef ref="put"/>
     <routeContextRef ref="delete"/>
 
-    <route>
-      <from uri="jetty:http://0.0.0.0:8888/islandora/rest/basic-image/"/>
-        <choice>
-          <when><simple>${headers.CamelHttpMethod} == 'GET'</simple>
-            <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
-            <to uri="direct:getBasicImage"/>
-          </when>
-          <when><simple>${headers.CamelHttpMethod} == 'POST'</simple>
-            <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
-            <setProperty propertyName="node"><simple>${headers.node}</simple></setProperty>
-            <filter>
-              <javaScript>request.hasAttachments()</javaScript>
-              <setProperty propertyName="attachment"><javaScript>request.getAttachments().values().toArray()[0]</javaScript></setProperty>
-            </filter>
-            <setProperty propertyName="mimetype"><simple>${headers.mimetype}</simple></setProperty>
-            <to uri="direct:getCollectionUri"/>
-            <to uri="direct:createBasicImage"/>
-          </when>
-          <when><simple>${headers.CamelHttpMethod} == 'PUT'</simple>
-            <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
-            <setProperty propertyName="node"><simple>${headers.node}</simple></setProperty>
-            <filter>
-              <javaScript>request.hasAttachments()</javaScript>
-              <setProperty propertyName="attachment"><javaScript>request.getAttachments().values().toArray()[0]</javaScript></setProperty>
-            </filter>
-            <setProperty propertyName="mimetype"><simple>${headers.mimetype}</simple></setProperty>
-            <to uri="direct:updateBasicImage"/>
-          </when>
-          <when><simple>${headers.CamelHttpMethod} == 'DELETE'</simple>
-            <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
-            <to uri="direct:deleteBasicImage"/>
-          </when>
-        </choice>
-    </route>
+    <restConfiguration component="servlet" port="8888" contextPath="/islandora/rest/basic-image"/>
+
+    <rest>
+      <get url="/{uuid}">
+        <description>Get a basic image from Fedora</description>
+        <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
+        <to uri="direct:getBasicImage"/>
+      </get>
+
+      <post uri="/" consumes="application/json">
+        <description>Create a basic image in Fedora</description>
+        <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
+        <setProperty propertyName="node"><simple>${headers.node}</simple></setProperty>
+        <filter>
+          <javaScript>request.hasAttachments()</javaScript>
+          <setProperty propertyName="attachment"><javaScript>request.getAttachments().values().toArray()[0]</javaScript></setProperty>
+        </filter>
+        <setProperty propertyName="mimetype"><simple>${headers.mimetype}</simple></setProperty>
+        <to uri="direct:getCollectionUri"/>
+        <to uri="direct:createBasicImage"/>
+      </post>
+
+      <put uri="/{uuid}/{node}">
+        <description>Update a basic image in Fedora</description>
+        <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
+        <setProperty propertyName="node"><simple>${headers.node}</simple></setProperty>
+        <filter>
+          <javaScript>request.hasAttachments()</javaScript>
+          <setProperty propertyName="attachment"><javaScript>request.getAttachments().values().toArray()[0]</javaScript></setProperty>
+        </filter>
+        <setProperty propertyName="mimetype"><simple>${headers.mimetype}</simple></setProperty>
+        <to uri="direct:updateBasicImage"/>
+      </put>
+
+      <delete uri="/{uuid}">
+        <description>Delete a basic image from Fedora</description>
+        <setProperty propertyName="uuid"><simple>${headers.uuid}</simple></setProperty>
+        <to uri="direct:deleteBasicImage"/>
+      </delete>
+    </rest>
   </camelContext>
 
 </blueprint>


### PR DESCRIPTION
This normalizes the REST dsl usage in the camel routes. @daniel-dgi will *definitely* need to look closely at this commit to make sure I didn't mess this up (esp. the PUT facade). n.b. I changed this from using the `jetty` component to using the `servlet` component because that's what the `collections-service` uses.