### PR TITLE
Collection Service Implementation 

### DIFF
--- a/services/CollectionService/composer.json
+++ b/services/CollectionService/composer.json
@@ -1,24 +1,19 @@
 {
     "name": "islandora/collection-service",
-    "description": "RESTful service providing resources in Fedora 4",
-    "repositories": [
-        {
-	    "type": "vcs",
-            "url": "https://github.com/Islandora-CLAW/chullo"
-
-        },
-        {
-            "type": "path",
-            "url": "/Users/dpino/Desktop/Development/ISLANDORAWORK/CLAW_MICRO/islandora/services/ResourceServiceProvider"
-        }    
-    ],
+    "description": "RESTful service providing PCDM Collections in Fedora 4",
+    "repositories": [{
+                "type": "path",
+                "url": "../ResourceServiceProvider"
+    }],
     "require": {
-        "islandora/chullo": "dev-master",
+        "islandora/chullo": "^0.0",
         "islandora/resource-service" : "dev-sprint-002",
         "silex/silex": "^1.3",
         "symfony/config": "^3.0",
         "twig/twig": "^1.23",
-        "symfony/yaml": "^3.0"
+        "symfony/yaml": "^3.0",
+        "easyrdf/easyrdf": "^0.9.1",
+        "ml/json-ld": "^1.0"
     },
     "autoload": {
         "psr-4": {"Islandora\\CollectionService\\": "src/"}

--- a/services/CollectionService/config/settings.dev.yml
+++ b/services/CollectionService/config/settings.dev.yml
@@ -1,5 +1,6 @@
 # Islandora Dev Settings to be used with $app['debug'] == TRUE
 islandora:
+  apiVersion: 0.0.1
   fedoraProtocol: http
   fedoraHost: "localhost:8080"
   fedoraPath: /rest
@@ -7,3 +8,5 @@ islandora:
   tripleHost: "localhost:9999"
   triplePath: /bigdata/sparql
   resourceIdRegex: "(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})?"
+  # This domain is used as namespace (hashed) when generating UUID V5 identifiers, replace with your own
+  defaultNamespaceDomainUuuidV5: "www.islandora.ca"

--- a/services/CollectionService/config/settings.yml
+++ b/services/CollectionService/config/settings.yml
@@ -1,4 +1,5 @@
 islandora:
+  apiVersion: 0.0.1
   fedoraProtocol: http
   fedoraHost: "localhost:8080"
   fedoraPath: /fcrepo/rest
@@ -6,3 +7,5 @@ islandora:
   tripleHost: "localhost:8080"
   triplePath: /bigdata/sparql
   resourceIdRegex: "(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})?"
+  # This domain is used as namespace (hashed) when generating UUID V5 identifiers, replace with your own
+  defaultNamespaceDomainUuuidV5: "www.islandora.ca"

--- a/services/CollectionService/src/index.php
+++ b/services/CollectionService/src/index.php
@@ -95,7 +95,7 @@ $app->post("/islandora/collection/{id}", function (Request $request, $id) use ($
       $graph->addResource($fakeIri,"http://www.islandora.ca/ontologies/2016/02/28/isl/v1.0/hasURN",'urn:uuid:'.$tmpUuid); //Testing an Islandora Ontology
     }
     //Restore LDP <> IRI on serialised graph
-    $pcmd_collection_rdf= preg_replace('/'.$fakeIri.'/', '', $graph->serialise('turtle'));
+    $pcmd_collection_rdf= str_replace($fakeIri, '', $graph->serialise('turtle'));
   }
 
   $urlRoute = $request->getUriForPath('/islandora/resource/');

--- a/services/CollectionService/src/index.php
+++ b/services/CollectionService/src/index.php
@@ -49,13 +49,13 @@ $app->view(function (ResponseInterface $psr7) {
 });
 
 /**
- * Collection POST route. takes $id (valid UUID or empty) for the parent resource as first value to match
- * takes 'rx' as optional query arguments
+ * Collection POST route. 
+ * Takes $id (valid UUID or empty) for the parent resource as first value to match, 
+ * and also takes 'rx' as an optional query argument.
  */
 $app->post("/islandora/collection/{id}", function (Request $request, $id) use ($app) {
   $tx = $request->query->get('tx', "");
-  
-  
+
   //Check for format
   $format = NULL;
   try {

--- a/services/CollectionService/src/index.php
+++ b/services/CollectionService/src/index.php
@@ -5,15 +5,12 @@ namespace Islandora\CollectionService;
 require_once __DIR__.'/../vendor/autoload.php';
 
 use Silex\Application;
-use Islandora\Chullo\FedoraApi;
-use Islandora\Chullo\TriplestoreClient;
 use Islandora\ResourceService\Provider\ResourceServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Psr\Http\Message\ResponseInterface;
 use Silex\Provider\TwigServiceProvider;
-use Symfony\Component\Yaml\Yaml;
 
 date_default_timezone_set('UTC');
 
@@ -25,38 +22,23 @@ $app->register(new \Silex\Provider\TwigServiceProvider(), array(
   'twig.path' => __DIR__.'/../templates',
 ));
 
-$app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
-  return $twig;
-}));
 $islandoraResourceServiceProvider = new \Islandora\ResourceService\Provider\ResourceServiceProvider;
 
-$app->register($islandoraResourceServiceProvider);
+//Registers Resource Service and defines current app's path for config context
+$app->register($islandoraResourceServiceProvider, array(
+  'islandora.BasePath' => __DIR__,
+));
 $app->mount("/islandora", $islandoraResourceServiceProvider);
 $app->register(new \Islandora\ResourceService\Provider\UuidServiceProvider(), array(
   'UuidServiceProvider.default_namespace' => $app['config']['islandora']['defaultNamespaceDomainUuuidV5'],
 ));
 
-//$app['uuid'] = $app['islandora.uuid5'](rand());
+//We will use a static uuid5 to fake a real IRI to replace <> during turtle parsing
+$app['uuid5'] = $app->share(function () use ($app) {
+  return $app['islandora.uuid5']($app['config']['islandora']['fedoraProtocol'].'://'.$app['config']['islandora']['fedoraHost'].$app['config']['islandora']['fedoraPath']);
+});
+//This is the uuidV4 generator
 $app['uuid'] = $app['islandora.uuid4'];
-
-/**
- * Still Not used, this function will check for content type
-*/
-$isFedora4Content = function (Request $request) use ($app) {
-  $rdf_content_types = array(
-    "text/turtle",
-    "text/rdf+n3",
-    "application/n3",
-    "text/n3",
-    "application/rdf+xml",
-    "application/n-triples",
-    "application/sparql-update"
-  );
-  if (in_array($request->headers->get('Content-type'), $rdf_content_types)) {
-    return true;
-  }
-  return false;
-};
 
 /**
  * Convert returned Guzzle responses to Symfony responses.
@@ -67,40 +49,123 @@ $app->view(function (ResponseInterface $psr7) {
 });
 
 /**
- * Collection POST route test. Does nothing more than redirect from collection to mounted 
- * takes 'rx' and/or 'checksum' as optional query arguments
+ * Collection POST route. takes $id (valid UUID or empty) for the parent resource as first value to match
+ * takes 'rx' as optional query arguments
  */
-$app->post("/islandora/collection",function (Application $app, Request $request) {
-   error_log($app['uuid']);
-   $tx = $request->query->get('tx', "");
-   $url = $request->getUriForPath('/islandora/resource/');
-   error_log($url);
-   //static public Request create(string $uri, string $method = 'GET', array $parameters = array(), array $cookies = array(), array $files = array(), array $server = array(), string $content = null)
-   $subRequest = Request::create($url, 'GET', array(), $request->cookies->all(), $request->files->all(), $request->server->all());
-   error_log($subRequest->__toString());
-   $response = $app->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
-   return $response;
+$app->post("/islandora/collection/{id}", function (Request $request, $id) use ($app) {
+  $tx = $request->query->get('tx', "");
+  //Check for format
+  $format = NULL;
+  try {
+    $format = \EasyRdf_Format::getFormat($request->headers->get('Content-Type'));
+  } catch (\EasyRdf_Exception $e) {
+    $app->abort(415, $e->getMessage());
+  }
+
+  //Now check if body can be parsed in that format
+  if ($format) { //EasyRdf_Format
+    //@see http://www.w3.org/2011/rdfa-context/rdfa-1.1 for defaults
+    \EasyRdf_Namespace::set('pcdm', 'http://pcdm.org/models#');
+    \EasyRdf_Namespace::set('nfo', 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/');
+    \EasyRdf_Namespace::set('isl', 'http://www.islandora.ca/ontologies/2016/02/28/isl/v1.0/');
+    \EasyRdf_Namespace::set('ldp', 'http://www.w3.org/ns/ldp');
+
+    //Fake IRI, default LDP one for current resource "<>" is not a valid IRI!
+    $fakeIri = new \EasyRdf_ParsedUri('urn:uuid:'.$app['uuid5']);
+
+    $graph = new \EasyRdf_Graph();
+    try {
+      $graph->parse($request->getContent(), $format->getName(), $fakeIri);
+    } catch (\EasyRdf_Exception $e) {
+      $app->abort(415, $e->getMessage());
+    }
+    //Add a pcmd:Collection type
+    $graph->resource($fakeIri, 'pcdm:Collection');
+
+    //Check if we got an UUID inside posted RDF. We won't validate it here because it's the caller responsability
+    if (NULL != $graph->countValues($fakeIri, '<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/uuid>')) {
+      $existingUuid = $graph->getLiteral($uri, '<http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/uuid>');
+      $graph->addResource($fakeIri, 'http://www.islandora.ca/ontologies/2016/02/28/isl/v1.0/hasURN', 'urn:uuid:'.$existingUuid); //Testing an Islandora Ontology!
+    } else {
+      //No UUID from the caller in RDF, lets put something there
+      $tmpUuid = $app['uuid']; //caching here, since it's regenerated each time it is used and I need the same twice
+      $graph->addLiteral($fakeIri,"http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/uuid",$tmpUuid); //Keeps compat for now with other services
+      $graph->addResource($fakeIri,"http://www.islandora.ca/ontologies/2016/02/28/isl/v1.0/hasURN",'urn:uuid:'.$tmpUuid); //Testing an Islandora Ontology
+    }
+    //Restore LDP <> IRI on serialised graph
+    $pcmd_collection_rdf= preg_replace('/'.$fakeIri.'/', '', $graph->serialise('turtle'));
+  }
+
+  $urlRoute = $request->getUriForPath('/islandora/resource/');
+  $request->headers->set('Content-Type', 'text/turtle');
+  $subRequestPost = Request::create($urlRoute.$id, 'POST', array(), $request->cookies->all(), $request->files->all(), $request->server->all(), $pcmd_collection_rdf);
+  $subRequestPost->query->set('tx', $tx);
+  $responsePost = $app->handle($subRequestPost, HttpKernelInterface::SUB_REQUEST, false);
+
+  if (201 == $responsePost->getStatusCode()) {// OK, collection created
+    //Lets take the location header in the response
+    $indirect_container_rdf = $app['twig']->render('createIndirectContainerfromTS.ttl', array(
+      'resource' => $responsePost->headers->get('location'),
+    ));
+
+    $subRequestPut = Request::create($urlRoute.$id, 'PUT', array(), $request->cookies->all(), array(), $request->server->all(), $indirect_container_rdf);
+    $subRequestPut->query->set('tx', $tx);
+    $subRequestPut->headers->set('Slug', 'members');
+    //Can't use in middleware, but needed. Without Fedora 4 throws big java errors!
+    $subRequestPut->headers->set('Host', $app['config']['islandora']['fedoraHost'], TRUE);
+    //Here is the thing. We don't know if UUID of the collection we just created is already in the tripple store.
+    //So what to do? We could just try to use our routes directly, but UUID check agains triplestore we could fail!
+    //lets invoke the controller method directly
+    $responsePut = $app['islandora.resourcecontroller']->put($app, $subRequestPut, $responsePost->headers->get('location'), "members");
+    if (201 == $responsePut->getStatusCode()) {// OK, indirect container created
+      //Return only the last created resource
+      $putHeaders = $responsePut->getHeaders();
+      //Guzzle psr7 response objects are inmutable. So we have to make this an array and add directly
+      $putHeaders['Link'] = array('<'.$urlRoute.$tmpUuid.'/members>; rel="alternate"');
+
+      return new Response($responsePut->getBody(), 200, $putHeaders);
+    }
+
+    return $responsePut;
+  }
+  //Abort if PCDM collection object could not be created
+  $app->abort($responsePost->getStatusCode(), 'Failed creating PCDM Collection');
+})
+->value('id',"");
+
+$app->after(function (Request $request, Response $response) use ($app) {
+  $response->headers->set('X-Powered-By', 'Islandora Collection REST API v'.$app['config']['islandora']['apiVersion'], TRUE); //Nice
+
 });
 
-$app->error(function (\Symfony\Component\HttpKernel\Exception\HttpException $e, $code) use ($app){
+//Common error Handling
+$app->error(function (\EasyRdf_Exception $e, $code) use ($app) {
   if ($app['debug']) {
     return;
   }
-  return new response(sprintf('Islandora Resource Service exception: %s / HTTP %d response', $e->getMessage(), $code), $code);
+
+  return new response(sprintf('RDF Library exception', $e->getMessage(), $code), $code);
 });
-$app->error(function (\Symfony\Component\HttpKernel\Exception\NotFoundHttpException $e, $code) use ($app){
+$app->error(function (\Symfony\Component\HttpKernel\Exception\HttpException $e, $code) use ($app) {
+  if ($app['debug']) {
+    return;
+  }
+
+  return new response(sprintf('Islandora Collection Service exception: %s / HTTP %d response', $e->getMessage(), $code), $code);
+});
+$app->error(function (\Symfony\Component\HttpKernel\Exception\NotFoundHttpException $e, $code) use ($app) {
   if ($app['debug']) {
     return;
   }
   //Not sure what the best "verbose" message is
-  return new response(sprintf('Islandora Resource Service exception: %s / HTTP %d response', $e->getMessage(), $code), $code);
+  return new response(sprintf('Islandora Collection Service exception: %s / HTTP %d response', $e->getMessage(), $code), $code);
 });
-$app->error(function (\Exception $e, $code) use ($app){
+$app->error(function (\Exception $e, $code) use ($app) {
   if ($app['debug']) {
     return;
-  }  
-  return new response(sprintf('Islandora Resource Service uncatched exception: %s %d response', $e->getMessage(), $code), $code);
-});
+  }
 
+  return new response(sprintf('Islandora Collection Service uncatched exception: %s %d response', $e->getMessage(), $code), $code);
+});
 
 $app->run();

--- a/services/CollectionService/src/index.php
+++ b/services/CollectionService/src/index.php
@@ -127,7 +127,7 @@ $app->post("/islandora/collection/{id}", function (Request $request, $id) use ($
       //Guzzle psr7 response objects are inmutable. So we have to make this an array and add directly
       $putHeaders['Link'] = array('<'.$urlRoute.$tmpUuid.'/members>; rel="alternate"');
 
-      return new Response($responsePut->getBody(), 200, $putHeaders);
+      return new Response($responsePut->getBody(), 201, $putHeaders);
     }
 
     return $responsePut;

--- a/services/CollectionService/templates/createIndirectContainerfromTS.sparql
+++ b/services/CollectionService/templates/createIndirectContainerfromTS.sparql
@@ -1,5 +1,0 @@
-PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.2/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-SELECT ?s WHERE {
-  ?s nfo:uuid "{{uuid}}"^^<http://www.w3.org/2001/XMLSchema#string> .
-}

--- a/services/CollectionService/templates/createIndirectContainerfromTS.ttl
+++ b/services/CollectionService/templates/createIndirectContainerfromTS.ttl
@@ -1,0 +1,8 @@
+@prefix ldp: <http://www.w3.org/ns/ldp#> .
+@prefix pcdm: <http://pcdm.org/models#> .
+@prefix ore: <http://www.openarchives.org/ore/terms/> .
+
+<> a ldp:IndirectContainer ;
+  ldp:membershipResource <{{ resource }}> ;
+  ldp:hasMemberRelation pcdm:hasMember ;
+  ldp:insertedContentRelation ore:proxyFor .

--- a/services/CollectionService/templates/createPCDMCollectionfromTS.sparql
+++ b/services/CollectionService/templates/createPCDMCollectionfromTS.sparql
@@ -1,5 +1,0 @@
-PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.2/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-SELECT ?s WHERE {
-  ?s nfo:uuid "{{uuid}}"^^<http://www.w3.org/2001/XMLSchema#string> .
-}

--- a/services/ResourceServiceProvider/composer.json
+++ b/services/ResourceServiceProvider/composer.json
@@ -1,14 +1,8 @@
 {
     "name": "islandora/resource-service",
     "description": "RESTful service providing resources in Fedora 4",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Islandora-CLAW/chullo"
-        }
-    ],
     "require": {
-        "islandora/chullo": "dev-master",
+        "islandora/chullo": "^0.0",
         "silex/silex": "^1.3",
         "symfony/config": "^3.0",
         "twig/twig": "^1.23",

--- a/services/ResourceServiceProvider/config/settings.yml
+++ b/services/ResourceServiceProvider/config/settings.yml
@@ -6,5 +6,5 @@ islandora:
   tripleHost: "localhost:8080"
   triplePath: /bigdata/sparql
   resourceIdRegex: "(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})?"
-  # This domain is used as namespace (hashed) when generating UUID V5 identifiers, replace with your own
+# This domain is used as namespace (hashed) when generating UUID V5 identifiers, replace with your own
   defaultNamespaceDomainUuuidV5: "www.islandora.ca"

--- a/services/ResourceServiceProvider/src/Provider/ResourceServiceProvider.php
+++ b/services/ResourceServiceProvider/src/Provider/ResourceServiceProvider.php
@@ -22,6 +22,9 @@ class ResourceServiceProvider implements ServiceProviderInterface, ControllerPro
     //
     // Define controller services
     //
+    //This is the base path for the application. Used to change the location
+    //of yaml config files when registerd somewhere else
+    $app['islandora.BasePath'] = __DIR__.'/..';
     $app['islandora.resourcecontroller'] = $app->share(function() use ($app) {
       return new \Islandora\ResourceService\Controller\ResourceController($app);
     });
@@ -45,12 +48,14 @@ class ResourceServiceProvider implements ServiceProviderInterface, ControllerPro
     */
     if (!isset($app['config'])) {
       $app['config'] = $app->share(function() use ($app){
-        if ($app['debug']) {
-          $configFile = __DIR__.'/../../config/settings.dev.yml';
-        }
-        else {
-          $configFile = __DIR__.'/../../config/settings.yml';
-        }
+         {
+          if ($app['debug']) {
+            $configFile = $app['islandora.BasePath'].'/../config/settings.dev.yml';
+          }
+          else {
+            $configFile = $app['islandora.BasePath'].'/../config/settings.yml';
+          }
+        }    
         $settings = Yaml::parse(file_get_contents($configFile));
         return $settings;
       });
@@ -118,49 +123,32 @@ class ResourceServiceProvider implements ServiceProviderInterface, ControllerPro
    * Part of ControllerProviderInterface
    */
   public function connect(Application $app) {
-    $controllers = $app['controllers_factory'];
+    $ResourceControllers = $app['controllers_factory'];
     //
     // Define routing referring to controller services
     //
-    $controllers->get("/resource/{id}/{child}", "islandora.resourcecontroller:get")
+    $ResourceControllers
       ->convert('id', $app['islandora.idToUri'])
       ->assert('id',$app['config']['islandora']['resourceIdRegex'])
       ->before($app['islandora.hostHeaderNormalize']) 
       ->before($app['islandora.htmlHeaderToTurtle'])
-      ->value('id',"")
+      ->value('id',"");
+    
+    
+    $ResourceControllers->get("/resource/{id}/{child}", "islandora.resourcecontroller:get")
       ->value('child',"")
       ->bind('islandora.resourceGet');
-    $controllers->post("/resource/{id}", "islandora.resourcecontroller:post")
-      ->convert('id', $app['islandora.idToUri'])
-      ->assert('id',$app['config']['islandora']['resourceIdRegex'])
-      ->before($app['islandora.hostHeaderNormalize']) 
-      ->before($app['islandora.htmlHeaderToTurtle'])
-      ->value('id',"")
+    $ResourceControllers->post("/resource/{id}", "islandora.resourcecontroller:post")
       ->bind('islandora.resourcePost');
-    $controllers->put("/resource/{id}/{child}", "islandora.resourcecontroller:put")
-      ->convert('id', $app['islandora.idToUri'])
-      ->assert('id',$app['config']['islandora']['resourceIdRegex'])
-      ->before($app['islandora.hostHeaderNormalize']) 
-      ->before($app['islandora.htmlHeaderToTurtle'])
-      ->value('id',"")
+    $ResourceControllers->put("/resource/{id}/{child}", "islandora.resourcecontroller:put")
       ->value('child',"")
       ->bind('islandora.resourcePut');
-    $controllers->patch("/resource/{id}/{child}", "islandora.resourcecontroller:patch")
-      ->convert('id', $app['islandora.idToUri'])
-      ->assert('id',$app['config']['islandora']['resourceIdRegex'])
-      ->before($app['islandora.hostHeaderNormalize']) 
-      ->before($app['islandora.htmlHeaderToTurtle'])
-      ->value('id',"")
+    $ResourceControllers->patch("/resource/{id}/{child}", "islandora.resourcecontroller:patch")
       ->value('child',"")
       ->bind('islandora.resourcePatch');
-    $controllers->delete("/resource/{id}/{child}", "islandora.resourcecontroller:delete")
-      ->convert('id', $app['islandora.idToUri'])
-      ->assert('id',$app['config']['islandora']['resourceIdRegex'])
-      ->before($app['islandora.hostHeaderNormalize']) 
-      ->before($app['islandora.htmlHeaderToTurtle'])
-      ->value('id',"")
+    $ResourceControllers->delete("/resource/{id}/{child}", "islandora.resourcecontroller:delete")
       ->value('child',"")
       ->bind('islandora.resourceDelete');
-    return $controllers;
+    return $ResourceControllers;
   }
 }


### PR DESCRIPTION
## Sprint 003 Work and after

# What does this Pull Request do?

Implements Collection Service with RDF aggregator.
Implements a pseudo monolithic PCDM Collection microservice implementation using ResourceServiceProvider
This services is built on one POST route, following the same logic as a ResourceService POST Route
Accepts and extra $uuid to be used as base resource for the PCDM collection 
Some updates to composer and ResourceServiceProvider (not breaking)

# What's new?

The collection Service accepts every RDF language/serialisation EasyRdf accepts via POST
Adds PCDM triples and UUID predicates (with an islandora experimental one) to given rdf body
If RDF body is empty it creates the resources too
Also: 
* Clean up of composer.json to use 0.0.2 chullo package
* Allows Resource Service Config yaml files to be overridden by implementing app
* Adds a common route collection to ResourceService unifying some middleware

# How should  Collection Service be tested? 

Similar as the previous ResourceService, only POST Route needed

Basic (Manual testing, be sure to have a working composer environment)
 1. Download/clone/diff/patch
 2. Modify config/settings.dev.yml to match your triplestore and fedora4 URLs, if running without any code change (this settings file depends on the enabled `$app['debug'] = true` definition in index.php
 3. If testing from a patch update composer.json resource-service version to match your git branch
 4. run $ composer update 
 5. run $ php -S localhost:8282 -t src src/index.php this will use the php embed web server to test
 6. Assure you have a fedora4 repo and a triple store running

Assuming you already have some containers in fedora 4 (with `nfo:uuid "7ef68f6f-72ab-4708-b0f4-8ec1f07cd580"` for example) you can test the working route with a call like this (replace the uuid for one of yours)

 * `$ curl -XPOST http://localhost:8282/islandora/collection/7ef68f6f-72ab-4708-b0f4-8ec1f07cd580 -v `
This will create a PCDM collection inside an existing Fedora4 Resource with `nfo:uuid "7ef68f6f-72ab-4708-b0f4-8ec1f07cd580"` property.
  * This new resource will have two `uuid` related predicates added with a unique UUID V4 generated by the system (if not already present in rdf body):
`nfo:uuid` and `isl:hasURN`(last one experimental)
  * Will also create an indirect Container with slug members inside the previous PCDM Collection one with triples
  `ldp:hasMemberRelation pcdm:hasMember`
  `ldp:insertedContentRelation ore:proxyFor`

 * `$ curl -XPOST --data-binary "@body.rdf" -H "Content-Type:text/turtle"   "http://localhost:8282/islandora/collection/7ef68f6f-72ab-4708-b0f4-8ec1f07cd580?tx=sometransactionid" -v`
Accepts this query argument optional(the stuff after the ?)
*  tx=transactionid (Will fail if tx given and not a valid transactionid (404))
* body.rdf should be a file with rdf triples that matches the Content-Type specs: So if using `text/turtle` it could be something like this
```turtle
@prefix dc11: <http://purl.org/dc/elements/1.1/> .
<> dc11:title "My Awesome PCDM Collection of dings" .
```


Note: if you don't have a CLAW vagrant environment working you can use(only for testing)
Note2: look at the response headers… there are a few nice ones!

* https://wiki.duraspace.org/display/FEDORA40/Quick+Start (download and run fcrepo-webapp-4.5.0-jetty-console.jar)
* Download standalone blazegraph https://www.blazegraph.com/download/ and run it using the described method (please lower the java memory!)
* Create a new resource in Fedora4 using the rest api (or page),
 *Since you won't have an indexer running, issue an insert data command to blaze graph to be able to test (you can use the same rdf response from fedora4 for a resource + nfo:uuid property to match using the web admin at http://localhost:9999/bigdata/#update)

# Additional Notes:

This is a working but "test " Service that needs some cleanups, checks, (like the "use" statements) and can/will be moved in the future.

---
Thanks a lot!

Diego Pino Navarro
A dog & human friendly developer