### PR TITLE
Fix invalid base64 in JSON requests

### DIFF
--- a/camel/sync/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/camel/sync/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -33,6 +33,10 @@
   <camelContext id="IslandoraSync" xmlns="http://camel.apache.org/schema/blueprint">
     <routeContextRef ref="eventGateway"/>
     <routeContextRef ref="drupalAuthentication"/>
+    <dataFormats>
+      <!-- base64 encoded for transmission as part of JSON should not include CRLF characters. -->
+      <base64 lineLength="0" id="base64JSONSafe" />
+    </dataFormats>
   </camelContext>
 
   <!-- configuration of activemq component -->

--- a/camel/sync/src/main/resources/OSGI-INF/blueprint/eventGateway.xml
+++ b/camel/sync/src/main/resources/OSGI-INF/blueprint/eventGateway.xml
@@ -210,7 +210,7 @@
       <from uri="direct:drupalAddTn"/>
         <removeHeaders pattern="*"/>
         <setBody><simple>${property.binary}</simple></setBody>
-        <marshal ref="base64"/>
+        <marshal ref="base64JSONSafe"/>
         <setProperty propertyName="b64file"><simple>${body}</simple></setProperty>
         <transform><simple>{ "uuid" : "${property.parentUuid}", "file" : "${property.b64file}", "mimetype" : "${property.mimetype}"}</simple></transform>
         <setHeader headerName="CamelHttpMethod"><constant>POST</constant></setHeader>
@@ -226,7 +226,7 @@
       <from uri="direct:drupalAddMediumSize"/>
         <removeHeaders pattern="*"/>
         <setBody><simple>${property.binary}</simple></setBody>
-        <marshal ref="base64"/>
+        <marshal ref="base64JSONSafe"/>
         <setProperty propertyName="b64file"><simple>${body}</simple></setProperty>
         <transform><simple>{ "uuid" : "${property.parentUuid}", "file" : "${property.b64file}", "mimetype" : "${property.mimetype}"}</simple></transform>
         <setHeader headerName="CamelHttpMethod"><constant>POST</constant></setHeader>


### PR DESCRIPTION
This change alters the JSON requests for adding thumbnail's and medium size
images, such that the base64 encoding of the image file no longer includes CRLF
characters every 78 characters; which is the default behavoir for the camel
base64 marshal.

This didn't arise as an issue previously since the PHP 5.5 code recieving it
didn't validate the JSON and simply ignored the CRLF characters, for versions of
PHP >=5.6 JSON is now validated, so we must send valid JSON.