### PR TITLE
Change line ending behavior, per #188

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+# We need this due to https://github.com/Islandora-CLAW/CLAW/issues/188.
+* text=auto
+* text eol=lf

--- a/README.md
+++ b/README.md
@@ -15,6 +15,40 @@ For more information about the project, please see the [project documentation](h
 * [drupal](https://github.com/Islandora-Labs/islandora/tree/7.x-2.x/drupal) - Drupal modules
 * [install](https://github.com/Islandora-Labs/islandora/tree/7.x-2.x/install) - Vagrant development environment
 
+
+## Requirements
+
+1. [VirtualBox](https://www.virtualbox.org/)
+2. [Vagrant](http://www.vagrantup.com)
+3. [git](https://git-scm.com/)
+
+## Variables
+
+### System Resources
+
+By default the virtual machine that is built uses 2GB of RAM. Your host machine will need to be able to support the additional memory use. You can override the CPU and RAM allocation by creating `ISLANDORA_VAGRANT_CPUS` and `ISLANDORA_VAGRANT_MEMORY` environment variables and setting the values. For example, on an Ubuntu host you could add to `~/.bashrc`:
+
+```bash
+export ISLANDORA_VAGRANT_CPUS=4
+export ISLANDORA_VAGRANT_MEMORY=4096
+```
+
+### Hostname and Description
+
+If you use a DNS or host file management plugin with Vagrant, you may want to set a specific hostname for the virtual machine. You can do that with the `ISLANDORA_VAGRANT_HOSTNAME` variable.  The `ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION` variables can be used to track the VM build. For example:
+
+```bash
+export ISLANDORA_VAGRANT_HOSTNAME="islandora-deux"
+export ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION="Islandora CLAW"
+```
+
+## Use
+
+1. `git clone https://github.com/Islandora-CLAW/CLAW`
+2. `cd CLAW`
+3. `vagrant up`
+
+
 ## Maintainers/Sponsors
 
 * UPEI

--- a/install/README.md
+++ b/install/README.md
@@ -92,22 +92,23 @@ The default VM login details are:
 
 If you receive errors involving `\r` (end of line) you have two options:
 
-#### Clone down the current development branch using `--single-branch`.
+1. Clone down the current development branch using `--single-branch`.
 
-Our current development branch (`sprint-002` as of 04-2016-23) will automatically take care of line endings for you. A benifit to this approach is that files created or edited on a Windows environment will be pushed back to your fork with appropriate `LF` endings.
+  Our current development branch (`sprint-002` as of 04-2016-23) will automatically take care of line endings for you. 
 
-```
-git clone --single-branch --branch sprint-002 git@github.com:Islandora-CLAW/CLAW.git <optional directory name>
-```
+  ```
+  git clone --single-branch --branch sprint-002 git@github.com:Islandora-CLAW/CLAW.git <optional directory name>
+  ```
+  A benifit to this approach is that files created or edited on a Windows environment will be pushed back to your fork with appropriate `LF` endings.
 
-#### Modify your global `.gitconfig` file to disable the Windows behavior of `autocrlf` entirely.
+2. Modify your global `.gitconfig` file to disable the Windows behavior of `autocrlf` entirely.
 
-Edit the global `.gitconfig` file, find the line:
-```
-autocrlf = true
-```
-and change it to
-```
-autocrlf = false
-```
-Remove and clone again. This will prevent Windows git clients from automatically replacing Unix line endings LF with Windows line endings CRLF.
+  Edit the global `.gitconfig` file, find the line:
+  ```
+  autocrlf = true
+  ```
+  and change it to
+  ```
+  autocrlf = false
+  ```
+  Remove and clone again. This will prevent Windows git clients from automatically replacing Unix line endings LF with Windows line endings CRLF.

--- a/install/README.md
+++ b/install/README.md
@@ -87,3 +87,17 @@ The default VM login details are:
 - Islandora 7.x-2.x
 - PHP 5.5.9 
 - Java 8 (Oracle)
+
+## Windows Troubleshooting
+
+If you receive errors involving `\r` (end of line):
+
+Edit the global `.gitconfig` file, find the line:
+```
+autocrlf = true
+```
+and change it to
+```
+autocrlf = false
+```
+Remove and clone again. This will prevent Windows git clients from automatically replacing Unix line endings LF with Windows line endings CRLF.

--- a/install/README.md
+++ b/install/README.md
@@ -94,8 +94,6 @@ If you receive errors involving `\r` (end of line) you have two options:
 
 1. Clone down the current development branch using `--single-branch`.
 
-  Our current development branch (`sprint-002` as of 04-2016-23) will automatically take care of line endings for you. 
-
   ```
   git clone --single-branch --branch sprint-002 git@github.com:Islandora-CLAW/CLAW.git <optional directory name>
   ```

--- a/install/README.md
+++ b/install/README.md
@@ -92,12 +92,13 @@ The default VM login details are:
 
 If you receive errors involving `\r` (end of line) you have two options:
 
-#### Clone down the current development branch using ``--single-branch``.
+#### Clone down the current development branch using `--single-branch`.
 
 Our current development branch (`sprint-002` as of 04-2016-23) will automatically take care of line endings for you. A benifit to this approach is that files created or edited on a Windows environment will be pushed back to your fork with appropriate `LF` endings.
 
-``git clone --single-branch --branch sprint-002 git@github.com:Islandora-CLAW/CLAW.git <optional directory name>``
-
+```
+git clone --single-branch --branch sprint-002 git@github.com:Islandora-CLAW/CLAW.git <optional directory name>
+```
 
 #### Modify your global `.gitconfig` file to disable the Windows behavior of `autocrlf` entirely.
 

--- a/install/README.md
+++ b/install/README.md
@@ -90,7 +90,16 @@ The default VM login details are:
 
 ## Windows Troubleshooting
 
-If you receive errors involving `\r` (end of line):
+If you receive errors involving `\r` (end of line) you have two options:
+
+#### Clone down the current development branch using ``--single-branch``.
+
+Our current development branch (`sprint-002` as of 04-2016-23) will automatically take care of line endings for you. A benifit to this approach is that files created or edited on a Windows environment will be pushed back to your fork with appropriate `LF` endings.
+
+``git clone --single-branch --branch sprint-002 git@github.com:Islandora-CLAW/CLAW.git <optional directory name>``
+
+
+#### Modify your global `.gitconfig` file to disable the Windows behavior of `autocrlf` entirely.
 
 Edit the global `.gitconfig` file, find the line:
 ```

--- a/install/Vagrantfile
+++ b/install/Vagrantfile
@@ -4,6 +4,11 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+$cpus   = ENV.fetch("ISLANDORA_VAGRANT_CPUS", "1")
+$memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "2048")
+$hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "islandora-deux")
+$virtualBoxDescription = ENV.fetch("ISLANDORA_VAGRANT_VIRTUALBOXDESCRIPTION", "IslandoraCLAW")
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,
@@ -13,7 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.network :forwarded_port, guest: 80, host: 8000 # Apache
   end
   
-  config.vm.hostname = "islandora-deux"
+  config.vm.hostname = $hostname
 
   # THIS NEEDS SOME LOVE. WEIRD SSH LOGIN ISSUES.
   # IT GETS STUCK AT: Waiting for ssh..
@@ -56,7 +61,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 5432, host: 5432 # PostgreSQL
 
   config.vm.provider "virtualbox" do |vb|
-    vb.customize ["modifyvm", :id, "--memory", '2048']
+    vb.customize ["modifyvm", :id, "--memory", $memory]
+    vb.customize ["modifyvm", :id, "--cpus", $cpus]
+    vb.customize ["modifyvm", :id, "--description", $virtualBoxDescription]
   end
 
   config.vm.provision :shell, inline: "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile", :privileged =>false


### PR DESCRIPTION
Added .gitattribute to resolve line ending issues on Windows computers when attempting to Vagrant up. Resolves #188.
Note: requires a Windows test before merge.