### PR TITLE
Update README.md - capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For more details, please check out the following resources:
 ## Maintainers
 
 * [Nick Ruest](https://github.com/ruebot)
-* [Daniel Lamb](https://github.com/daniel-dgi/)
+* [Daniel Lamb](https://github.com/dannylamb/)
 * [Jared Whiklo](https://github.com/whikloj)
 * [Diego Pino](https://github.com/DiegoPino)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Note: the [Ansible](https://github.com/Islandora-CLAW/claw-ansible) and [Docker]
 * Simon Fraser University
 * PALS
 * American Philosophical Society
-* common media inc.
+* Common Media Inc.
 
 ## Maintainers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ If you would like to contribute code to the project, you will need to be covered
 ## Maintainers
 
 * [Nick Ruest](https://github.com/ruebot)
-* [Daniel Lamb](https://github.com/daniel-dgi/)
+* [Daniel Lamb](https://github.com/dannylamb/)
 
 ## Licensing
 


### PR DESCRIPTION
Common Media uses capital case for their name. Not a big deal, but it was bugging me.