### PR TITLE
Install drupal-console using composer

### DIFF
--- a/install/Vagrantfile
+++ b/install/Vagrantfile
@@ -61,8 +61,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, :path => "./scripts/solr.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/loris.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/composer.sh", :args => home_dir
-  config.vm.provision :shell, :path => "./scripts/drupal-console.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/drupal.sh", :args => home_dir
+  config.vm.provision :shell, :path => "./scripts/drupal-console.sh", :args => home_dir, :privileged => false
   config.vm.provision :shell, :path => "./scripts/fcrepo.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/blazegraph.sh", :args => home_dir
   config.vm.provision :shell, :path => "./scripts/karaf.sh", :args => home_dir

--- a/install/scripts/drupal-console.sh
+++ b/install/scripts/drupal-console.sh
@@ -8,12 +8,24 @@ if [ -f "$HOME_DIR/islandora/install/configs/variables" ]; then
   . "$HOME_DIR"/islandora/install/configs/variables
 fi
 
-sed -i '$idate.timezone=America/Toronto' /etc/php/7.0/cli/php.ini
 cd /tmp
-curl https://drupalconsole.com/installer -L -o drupal.phar
-mv drupal.phar /usr/local/bin/drupal
-chmod +x /usr/local/bin/drupal
-cd /home/vagrant
-mkdir .console
-cp $HOME_DIR/islandora/install/configs/config.yml /home/vagrant/.console/config.yml
+#curl https://drupalconsole.com/installer -L -o drupal.phar
+#mv drupal.phar /usr/local/bin/drupal
+#chmod +x /usr/local/bin/drupal
+composer global require drupal/console:@stable
+echo "PATH=\$PATH:$HOME/.config/composer/vendor/bin" >> $HOME/.bash_profile
+cd $HOME
+~/.config/composer/vendor/bin/drupal init
+if [ ! -d ".console" ]; then
+  mkdir .console
+fi
+if [ -f ".console/config.yml" ]; then
+  rm .console/config.yml
+fi
+cp $HOME_DIR/islandora/install/configs/config.yml $HOME_DIR/.console/config.yml
 chown -hR vagrant:vagrant /home/vagrant/.console
+sed -i -e "\$asource \"$HOME/.console/console.rc\" 2>/dev/null" $HOME/.bashrc
+
+# Fix drupal-console
+cd /var/www/html/drupal
+~/.config/composer/vendor/bin/drupal settings:set checked "true"

--- a/install/scripts/lamp-server.sh
+++ b/install/scripts/lamp-server.sh
@@ -9,3 +9,5 @@ apt-get -qq install -y $PACKAGES
 usermod -a -G www-data vagrant
 
 chown -R vagrant:vagrant islandora
+
+sed -i '$idate.timezone=America/Toronto' /etc/php/7.0/cli/php.ini

--- a/install/scripts/loris.sh
+++ b/install/scripts/loris.sh
@@ -22,7 +22,7 @@ cd /opt
 mkdir djatoka
 cd /tmp || exit
 cp "$DOWNLOAD_DIR/adore-djatoka.tar.gz" /tmp
-tar -xzvf adore-djatoka.tar.gz
+tar -xzf adore-djatoka.tar.gz
 cd adore-djatoka-1.1 || exit
 mv -v ./* /opt/djatoka
 ln -s /opt/djatoka/bin/Linux-x86-64/kdu_compress /usr/local/bin/kdu_compress


### PR DESCRIPTION
Resolves #386 

Installing using composer seems to make it work with Drupal8. Also needed to remove the settings check as it is not working properly with PHP 7.

@MarcusBarnes @Natkeeran If you two could test this out and see if it works for you, that would be awesome.