### PR TITLE
Broadcaster 448

### DIFF
--- a/install/configs/karaf/alpaca.script
+++ b/install/configs/karaf/alpaca.script
@@ -1,2 +1,3 @@
 repo-add file:/home/ubuntu/Alpaca/karaf/build/resources/main/features.xml
+feature:install islandora-connector-broadcast
 feature:install islandora-indexing-triplestore

--- a/install/scripts/alpaca.sh
+++ b/install/scripts/alpaca.sh
@@ -12,6 +12,7 @@ cd "$HOME_DIR"
 git clone https://github.com/Islandora-CLAW/Alpaca.git
 cd Alpaca
 chown -R ubuntu:ubuntu "$HOME_DIR/Alpaca"
+chown -R ubuntu:ubuntu "$HOME_DIR/.m2"
 sudo -u ubuntu ./gradlew clean build install
 
 # Chown everything over to the ubuntu user just in case

--- a/install/scripts/alpaca.sh
+++ b/install/scripts/alpaca.sh
@@ -9,7 +9,7 @@ if [ -f "$HOME_DIR/islandora/install/configs/variables" ]; then
 fi
 
 cd "$HOME_DIR"
-git clone -b broadcaster-448 https://github.com/dannylamb/Alpaca.git
+git clone https://github.com/Islandora-CLAW/Alpaca.git
 cd Alpaca
 chown -R ubuntu:ubuntu "$HOME_DIR/Alpaca"
 sudo -u ubuntu ./gradlew clean build install

--- a/install/scripts/alpaca.sh
+++ b/install/scripts/alpaca.sh
@@ -9,10 +9,10 @@ if [ -f "$HOME_DIR/islandora/install/configs/variables" ]; then
 fi
 
 cd "$HOME_DIR"
-git clone https://github.com/Islandora-CLAW/Alpaca.git
+git clone -b broadcaster-448 https://github.com/dannylamb/Alpaca.git
 cd Alpaca
 chown -R ubuntu:ubuntu "$HOME_DIR/Alpaca"
-sudo -u ubuntu ./gradlew build
+sudo -u ubuntu ./gradlew clean build install
 
 # Chown everything over to the ubuntu user just in case
 chown -R ubuntu:ubuntu "$HOME_DIR/Alpaca"

--- a/install/scripts/config.sh
+++ b/install/scripts/config.sh
@@ -20,7 +20,7 @@ else
 fi
 
 if [ -f "$KARAF_DIR/etc/org.ops4j.datasource-idiomatic.cfg" ]; then
-  # Update fcrepo triplestore indexing config
+  # Update idiomatic datasource config
   sed -i 's|user=|user=root|' "$KARAF_DIR/etc/org.ops4j.datasource-idiomatic.cfg"
   sed -i 's|password=|password=islandora|' "$KARAF_DIR/etc/org.ops4j.datasource-idiomatic.cfg"
 else
@@ -28,17 +28,24 @@ else
 fi
 
 if [ -f "$KARAF_DIR/etc/edu.amherst.acdc.connector.broadcast.cfg" ]; then
-  # Update fcrepo triplestore indexing config
+  # Update fcrepo broadcaster config
   sed -i 's|message.recipients=|message.recipients=activemq:queue:acrepo-connector-idiomatic|' "$KARAF_DIR/etc/edu.amherst.acdc.connector.broadcast.cfg"
 else
   echo "$KARAF_DIR/etc/edu.amherst.acdc.connector.broadcast.cfg still doesn't exist, this is an ERROR!"
 fi
 
 if [ -f "$KARAF_DIR/etc/edu.amherst.acdc.connector.idiomatic.cfg" ]; then
-  # Update fcrepo triplestore indexing config
+  # Update idiomatic config
   sed -i 's|input.stream=broker:topic:fedora|input.stream=activemq:queue:acrepo-connector-idiomatic|' "$KARAF_DIR/etc/edu.amherst.acdc.connector.idiomatic.cfg"
   sed -i 's|id.property=dc:identifier|id.property=nfo:uuid|' "$KARAF_DIR/etc/edu.amherst.acdc.connector.idiomatic.cfg"
   sed -i 's|id.namespace=http://purl.org/dc/elements/1.1/|id.namespace=http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#|' "$KARAF_DIR/etc/edu.amherst.acdc.connector.idiomatic.cfg"
 else
   echo "$KARAF_DIR/etc/edu.amherst.acdc.connector.idiomatic.cfg still doesn't exist, this is an ERROR!"
+fi
+
+if [ -f "$KARAF_DIR/etc/ca.islandora.alpaca.connector.broadcast.cfg" ]; then
+  # Update islandora broadcaster config
+  sed -i 's|input.stream=broker:queue:islandora-connector-broadcast|input.stream=activemq:queue:islandora-connector-broadcast|' "$KARAF_DIR/etc/ca.islandora.alpaca.connector.broadcast.cfg"
+else
+  echo "$KARAF_DIR/etc/ca.islandora.alpaca.connector.broadcast.cfg still doesn't exist, this is an ERROR!"
 fi

--- a/install/scripts/islandora-karaf-components.sh
+++ b/install/scripts/islandora-karaf-components.sh
@@ -22,5 +22,5 @@ cp mysql-connector-java-"$MYSQL_CONNECTOR_VERSION"/mysql-connector-java-"$MYSQL_
 echo "Installing ID Mapping Service"
 $KARAF_CLIENT -f $KARAF_CONFIGS/islandora_id_mapping_service.script
 
-echo "Installing Islandora Triplestore Indexer"
-$KARAF_CLIENT -f $KARAF_CONFIGS/islandora_indexing_triplestore.script
+echo "Installing Alpaca"
+$KARAF_CLIENT -f $KARAF_CONFIGS/alpaca.script


### PR DESCRIPTION
This PR updates the install to include the changes from #448.

### Testing Instructions
This will require you to spin up a new box, but since https://github.com/Islandora-CLAW/Alpaca/pull/22 won't be merged until you can test this, there's some extra hoops to jump through.  Pull in the changes from this PR and then
- `cd /path/to/CLAW/install`
- `vagrant destroy`
- `sed -i 's|git clone https://github.com/Islandora-CLAW/Alpaca.git|git clone -b broadcaster-448 https://github.com/dannylamb/Alpaca.git|' scripts/alpaca.sh`
- `vagrant up`

Then once the VM is up and ready, you can test by verifying the feature has installed itself properly.
- `/opt/karaf/bin/client`
And from within the Karaf console
```
karaf@root()> feature:list | grep islandora-connector-broadcast
islandora-connector-broadcast           | 0.1.0.SNAPSHOT   | x        | Started     | islandora-karaf-0.1.0-SNAPSHOT |
```
The X means it's been installed.

You should also verify that the bundle is in the Active state
```
karaf@root()> bundle:list | grep islandora-connector-broadcast
242 | Active |  80 | 0.1.0.SNAPSHOT     | islandora-connector-broadcast
```

We're not set up for end-to-end integration testing yet (see #455), so in lieu of that, you can drop in this blueprint file in `/opt/karaf/deploy` and watch it go:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<blueprint
        xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
        xsi:schemaLocation="
      http://www.osgi.org/xmlns/blueprint/v1.0.0
      http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">

    <camelContext id="IslandoraConnectorBroadcastTest" xmlns="http://camel.apache.org/schema/blueprint">
      <route>
        <from uri="timer:foo?period=10000"/>
        <setHeader headerName="IslandoraBroadcastRecipients">
          <constant>activemq:queue:foo,activemq:queue:bar</constant>
        </setHeader>
        <to uri="activemq:queue:islandora-connector-broadcast"/>
      </route>

      <route>
        <from uri="activemq:queue:foo"/>
          <log message="FOO"/>
      </route>

      <route>
        <from uri="activemq:queue:bar"/>
          <log message="BAR"/>
      </route>

    </camelContext>

</blueprint>
```

From your karaf console, run `log:tail` and you should see the following fly by every ten seconds:
```
2016-12-13 18:20:53,787 | INFO  | ector-broadcast] | MessageBroadcaster               | 57 - org.apache.camel.camel-core - 2.17.3 | Distributing message: ID:islandora-deux-37839-1481576415159-45:1:1:1:4 with timestamp 1481653253781
2016-12-13 18:20:53,793 | DEBUG | ector-broadcast] | msConfiguration$CamelJmsTemplate | 81 - org.apache.servicemix.bundles.spring-jms - 3.2.14.RELEASE_1 | Executing callback on JMS Session: PooledSession { ActiveMQSession {id=ID:islandora-deux-37839-1481576415159-37:1:1,started=false} java.lang.Object@63e8bbf7 }
2016-12-13 18:20:53,795 | DEBUG | ector-broadcast] | JmsConfiguration                 | 58 - org.apache.camel.camel-jms - 2.17.3 | Sending JMS message to: queue://foo with message: ActiveMQMessage {commandId = 0, responseRequired = false, messageId = null, originalDestination = null, originalTransactionId = null, producerId = null, destination = null, transactionId = null, expiration = 0, timestamp = 0, arrival = 0, brokerInTime = 0, brokerOutTime = 0, correlationId = null, replyTo = null, persistent = true, type = null, priority = 4, groupID = null, groupSequence = 0, targetConsumerId = null, compressed = false, userID = null, content = null, marshalledProperties = null, dataStructure = null, redeliveryCounter = 0, size = 0, properties = {firedTime=Tue Dec 13 18:20:53 UTC 2016, breadcrumbId=ID-islandora-deux-40947-1481576413216-14-13, CamelJmsDeliveryMode=2, ca_DOT_islandora_DOT_alpaca_DOT_connector_DOT_broadcast_DOT_recipients=activemq:queue:foo,activemq:queue:bar}, readOnlyProperties = false, readOnlyBody = false, droppable = false, jmsXGroupFirstForConsumer = false}
2016-12-13 18:20:53,806 | DEBUG | JmsConsumer[foo] | faultJmsMessageListenerContainer | 81 - org.apache.servicemix.bundles.spring-jms - 3.2.14.RELEASE_1 | Received message of type [class org.apache.activemq.command.ActiveMQMessage] from consumer [PooledMessageConsumer { ActiveMQMessageConsumer { value=ID:islandora-deux-37839-1481576415159-41:1:1:1, started=true } }] of session [PooledSession { ActiveMQSession {id=ID:islandora-deux-37839-1481576415159-41:1:1,started=true} java.lang.Object@f50d1b0 }]
2016-12-13 18:20:53,806 | DEBUG | JmsConsumer[foo] | EndpointMessageListener          | 58 - org.apache.camel.camel-jms - 2.17.3 | Endpoint[activemq://queue:foo] consumer received JMS message: ActiveMQMessage {commandId = 9, responseRequired = true, messageId = ID:islandora-deux-37839-1481576415159-37:1:1:1:5, originalDestination = null, originalTransactionId = null, producerId = ID:islandora-deux-37839-1481576415159-37:1:1:1, destination = queue://foo, transactionId = null, expiration = 0, timestamp = 1481653253802, arrival = 0, brokerInTime = 1481653253803, brokerOutTime = 1481653253803, correlationId = null, replyTo = null, persistent = true, type = null, priority = 4, groupID = null, groupSequence = 0, targetConsumerId = null, compressed = false, userID = null, content = null, marshalledProperties = org.apache.activemq.util.ByteSequence@2a7db171, dataStructure = null, redeliveryCounter = 0, size = 0, properties = {CamelJmsDeliveryMode=2, firedTime=Tue Dec 13 18:20:53 UTC 2016, breadcrumbId=ID-islandora-deux-40947-1481576413216-14-13, ca_DOT_islandora_DOT_alpaca_DOT_connector_DOT_broadcast_DOT_recipients=activemq:queue:foo,activemq:queue:bar}, readOnlyProperties = true, readOnlyBody = true, droppable = false, jmsXGroupFirstForConsumer = false}
2016-12-13 18:20:53,806 | INFO  | JmsConsumer[foo] | route18                          | 57 - org.apache.camel.camel-core - 2.17.3 | FOO
2016-12-13 18:20:53,810 | DEBUG | ector-broadcast] | msConfiguration$CamelJmsTemplate | 81 - org.apache.servicemix.bundles.spring-jms - 3.2.14.RELEASE_1 | Executing callback on JMS Session: PooledSession { ActiveMQSession {id=ID:islandora-deux-37839-1481576415159-39:1:1,started=false} java.lang.Object@23023150 }
2016-12-13 18:20:53,811 | DEBUG | ector-broadcast] | JmsConfiguration                 | 58 - org.apache.camel.camel-jms - 2.17.3 | Sending JMS message to: queue://bar with message: ActiveMQMessage {commandId = 0, responseRequired = false, messageId = null, originalDestination = null, originalTransactionId = null, producerId = null, destination = null, transactionId = null, expiration = 0, timestamp = 0, arrival = 0, brokerInTime = 0, brokerOutTime = 0, correlationId = null, replyTo = null, persistent = true, type = null, priority = 4, groupID = null, groupSequence = 0, targetConsumerId = null, compressed = false, userID = null, content = null, marshalledProperties = null, dataStructure = null, redeliveryCounter = 0, size = 0, properties = {firedTime=Tue Dec 13 18:20:53 UTC 2016, breadcrumbId=ID-islandora-deux-40947-1481576413216-14-13, CamelJmsDeliveryMode=2, ca_DOT_islandora_DOT_alpaca_DOT_connector_DOT_broadcast_DOT_recipients=activemq:queue:foo,activemq:queue:bar}, readOnlyProperties = false, readOnlyBody = false, droppable = false, jmsXGroupFirstForConsumer = false}
2016-12-13 18:20:53,816 | DEBUG | JmsConsumer[bar] | faultJmsMessageListenerContainer | 81 - org.apache.servicemix.bundles.spring-jms - 3.2.14.RELEASE_1 | Received message of type [class org.apache.activemq.command.ActiveMQMessage] from consumer [PooledMessageConsumer { ActiveMQMessageConsumer { value=ID:islandora-deux-37839-1481576415159-43:1:1:1, started=true } }] of session [PooledSession { ActiveMQSession {id=ID:islandora-deux-37839-1481576415159-43:1:1,started=true} java.lang.Object@2d38faec }]
2016-12-13 18:20:53,817 | DEBUG | JmsConsumer[bar] | EndpointMessageListener          | 58 - org.apache.camel.camel-jms - 2.17.3 | Endpoint[activemq://queue:bar] consumer received JMS message: ActiveMQMessage {commandId = 9, responseRequired = true, messageId = ID:islandora-deux-37839-1481576415159-39:1:1:1:5, originalDestination = null, originalTransactionId = null, producerId = ID:islandora-deux-37839-1481576415159-39:1:1:1, destination = queue://bar, transactionId = null, expiration = 0, timestamp = 1481653253813, arrival = 0, brokerInTime = 1481653253813, brokerOutTime = 1481653253814, correlationId = null, replyTo = null, persistent = true, type = null, priority = 4, groupID = null, groupSequence = 0, targetConsumerId = null, compressed = false, userID = null, content = null, marshalledProperties = org.apache.activemq.util.ByteSequence@8159e60, dataStructure = null, redeliveryCounter = 0, size = 0, properties = {CamelJmsDeliveryMode=2, firedTime=Tue Dec 13 18:20:53 UTC 2016, breadcrumbId=ID-islandora-deux-40947-1481576413216-14-13, ca_DOT_islandora_DOT_alpaca_DOT_connector_DOT_broadcast_DOT_recipients=activemq:queue:foo,activemq:queue:bar}, readOnlyProperties = true, readOnlyBody = true, droppable = false, jmsXGroupFirstForConsumer = false}
2016-12-13 18:20:53,817 | INFO  | JmsConsumer[bar] | route19                          | 57 - org.apache.camel.camel-core - 2.17.3 | BAR
2016-12-13 18:20:53,824 | DEBUG | ector-broadcast] | MulticastProcessor               | 57 - org.apache.camel.camel-core - 2.17.3 | Done sequential processing 2 exchanges
```