### PR TITLE
Restoring group write perms to fcrepo4 data dir

### DIFF
--- a/install/scripts/bootstrap.sh
+++ b/install/scripts/bootstrap.sh
@@ -41,6 +41,10 @@ apt-get -y -qq install maven
 apt-get -y -qq install tomcat7 tomcat7-admin
 usermod -a -G tomcat7 ubuntu
 sed -i '$i<user username="islandora" password="islandora" roles="manager-gui"/>' /etc/tomcat7/tomcat-users.xml
+chown -R tomcat7:tomcat7 /var/lib/tomcat7
+chown -R tomcat7:tomcat7 /var/log/tomcat7
+chmod -R g+w /var/lib/tomcat7
+chmod -R g+w /var/log/tomcat7
 
 # Wget and curl
 apt-get -y -qq install wget curl

--- a/install/scripts/fcrepo.sh
+++ b/install/scripts/fcrepo.sh
@@ -25,7 +25,6 @@ cp -v $HOME_DIR/islandora/install/configs/claw.cnd /opt/fcrepo/configs
 chown -hR tomcat7:tomcat7 /opt/fcrepo
 
 chown tomcat7:tomcat7 /var/lib/tomcat7/fcrepo4-data
-chmod g-w /var/lib/tomcat7/fcrepo4-data
 
 echo "CATALINA_OPTS=\"\${CATALINA_OPTS} -Dfcrepo.modeshape.configuration=file:///opt/fcrepo/configs/repository.json\"" >> /etc/default/tomcat7;
 


### PR DESCRIPTION
Resolves #458 and #459 

### Testing instructions
After pulling in these changes and running `vagrant up`, the Fedora webapp should deploy and you should be able to access the admin UI.  Also, check catalina.out and you shouldn't see the errors we were previously getting.  See this gist: https://gist.github.com/dannylamb/cea486a82d1467baf70d67bf40e8f9b9 