### PR TITLE
Update Versioning Policy per https://github.com/Islandora-CLAW/CLAW/w…

### DIFF
--- a/docs/technical-documentation/versioning.md
+++ b/docs/technical-documentation/versioning.md
@@ -1,6 +1,10 @@
 # Versioning Policy
 
-Islandora CLAW uses [semantic versioning](http://semver.org/).
+Islandora CLAW uses [semantic versioning](http://semver.org/), except for Drupal modules.
+
+## Components
+
+### [Semantic Versioning](http://semver.org/)
 
 **Major version** . **Minor version** . **Patch**
 
@@ -8,28 +12,20 @@ Islandora CLAW uses [semantic versioning](http://semver.org/).
 - **Minor version**; New features, and does not break the API
 - **Patch**; Bug fixes, and never breaks backward compatability
 
-## Components
+Example: 1.2.3
 
 * [Alpaca](https://github.com/Islandora-CLAW/alpaca)
-* [Chullo](https://github.com/Islandora-CLAW/chullo)
 * [CLAW](https://github.com/Islandora-CLAW/CLAW)
-* [Crayfish](https://github.com/Islandora-CLAW/crayfish)
-* [PDX](https://github.com/Islandora-CLAW/pdx)
-* [claw-docker](https://github.com/Islandora-CLAW/claw-docker)
-* [claw-docker-all-in-one](https://github.com/Islandora-CLAW/claw-docker-all-in-one)
-* [claw-base](https://github.com/Islandora-CLAW/claw-docker-base)
-* [claw-blazegraph](https://github.com/Islandora-CLAW/claw-docker-blazegraph)
-* [claw-drupal](https://github.com/Islandora-CLAW/claw-docker-drupal)
-* [claw-fedora](https://github.com/Islandora-CLAW/claw-docker-fedora)
-* [claw-islandora](https://github.com/Islandora-CLAW/claw-docker-islandora)
-* [claw-islandora-karaf-components](https://github.com/Islandora-CLAW/claw-docker-islandora-karaf-components)
-* [claw-karaf](https://github.com/Islandora-CLAW/claw-docker-karaf)
-* [claw-mariadb](https://github.com/Islandora-CLAW/claw-docker-mariadb)
-* [claw-maven](https://github.com/Islandora-CLAW/claw-docker-maven)
-* [claw-open-jdk](https://github.com/Islandora-CLAW/claw-docker-open-jdk)
-* [claw-oracle-jdk](https://github.com/Islandora-CLAW/claw-docker-oracle-jdk)
-* [claw-solr](https://github.com/Islandora-CLAW/claw-docker-solr)
-* [claw-tomcat](https://github.com/Islandora-CLAW/claw-docker-tomcat)
-* [claw-ansible](https://github.com/Islandora-CLAW/claw-ansible)
-* [claw_install_profile](https://github.com/Islandora-CLAW/claw_install_profile)
-* [Islandora](https://github.com/Islandora-CLAW/islandora)
+* [claw_vagrant](https://github.com/Islandora-CLAW/claw_vagrant)
+
+### [Drupal Contrib Versioning](https://www.drupal.org/docs/8/choosing-a-drupal-version/what-do-version-numbers-mean-on-contributed-modules-and-themes)
+
+**Core Compatibility** - **Major** . **PatchLevel[-Extra]**
+
+Example: 8.x-1.1
+
+* [claw-jsonld](https://github.com/Islandora-CLAW/claw-jsonld)
+* [drupal-project](https://github.com/Islandora-CLAW/drupal-project)
+* [islandora](https://github.com/Islandora-CLAW/islandora)
+* [islandora collection](https://github.com/Islandora-CLAW/islandora_collection)
+* [islandora image](https://github.com/Islandora-CLAW/islandora_image)

--- a/docs/technical-documentation/versioning.md
+++ b/docs/technical-documentation/versioning.md
@@ -17,6 +17,7 @@ Example: 1.2.3
 * [Alpaca](https://github.com/Islandora-CLAW/alpaca)
 * [CLAW](https://github.com/Islandora-CLAW/CLAW)
 * [claw_vagrant](https://github.com/Islandora-CLAW/claw_vagrant)
+* [Syn](https://github.com/Islandora-CLAW/Syn)
 
 ### [Drupal Contrib Versioning](https://www.drupal.org/docs/8/choosing-a-drupal-version/what-do-version-numbers-mean-on-contributed-modules-and-themes)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ pages:
 - Technical Documentation:
     - 'Minimum Viable Product': 'mvp/mvp_doc.md'
     - 'How to build documenation': 'technical-documentation/docs-build.md'
-    - 'Semantic Versioning Policy': 'technical-documentation/versioning.md'
+    - 'Versioning Policy': 'technical-documentation/versioning.md'
 - Components:
     - 'Islandora CLAW': 'index.md'
     - 'Alpaca': 'alpaca/README.md'


### PR DESCRIPTION
**Github issue**: https://github.com/Islandora-CLAW/CLAW/wiki/March-8,-2017

# What does this Pull Request do?

Updates the Versioning Policy as per discussion on the March 8, 2017 CLAW Call

# What's new?

Removed a number of components that have been moved out of the Islandora-CLAW organization, added a couple that have been added to the organization, and split the policy into two parts; Semantic Versioning, and Drupal Contrib Versioning.

# How should this be tested?

Read the updated policy document, and if you agree with it, add a thumbs up.

@Islandora-CLAW/committers @manez @MarcusBarnes @Natkeeran @DonRichards @jyobb @bryjbrown @jonathangreen @uconnjeustis