### PR TITLE
Add Drupal Project syncing documentation

### DIFF
--- a/docs/technical-documentation/docs-build.md
+++ b/docs/technical-documentation/docs-build.md
@@ -2,6 +2,19 @@
 
 This documentation is built using [mkdocs](http://www.mkdocs.org/), a static site generator that is geared towards building project documentation. The documentation is created in the [Markdown](http://en.wikipedia.org/wiki/Markdown) format, and it all resides in the [`docs`](https://github.com/Islandora-CLAW/CLAW/tree/master/docs) directory in the repository. The organization of the documentation is controlled by the [`mkdocs.yml`](https://github.com/Islandora-CLAW/CLAW/blob/master/mkdocs.yml) in the root of the repository.
 
+## Prerequisites
+
+You will need to have `mkdocs` installed locally, as well as the mkdocs theme.
+
+Install `mkdocs`:
+
+`sudo -H pip install mkdocs`
+
+Install material theme:
+
+`sudo -H pip install mkdocs-material`
+
+
 ## Build and Deploy documentation
 
 Documentation is build by running to the following command in the root of the repository:

--- a/docs/technical-documentation/docs-build.md
+++ b/docs/technical-documentation/docs-build.md
@@ -14,8 +14,11 @@ Install material theme:
 
 `sudo -H pip install mkdocs-material`
 
-
 ## Build and Deploy documentation
+
+Make sure you have all the submodules:
+
+`git submodule update --init --recursive`
 
 Documentation is build by running to the following command in the root of the repository:
 

--- a/docs/technical-documentation/drupal-project.md
+++ b/docs/technical-documentation/drupal-project.md
@@ -1,0 +1,19 @@
+# Introduction
+
+Islandora CLAW makes use of [drupal-project](https://github.com/drupal-composer/drupal-project), a composer template for Drupal projects. We augment it with Islandora CLAW specific changes, and need to occassionaly pull in upstream changes. The process below outlines how we will do it in a consistent manner.
+
+# Pull in upstream changes
+
+1. Clone a fork of our fork to your or your institions GitHub organization:
+<br />  `git clone fork`
+2. Add the drupal-composer repository as a remote:
+<br /> `git remote add upstream https://github.com/drupal-composer/drupal-project.git`
+3. Fetch everything:
+<br /> `git fetch --all`
+4. Create a branch to pull in changes that is based off the Islandora-CLAW 8.x-1.x branch: 
+<br /> `git checkout -b sync-upstream`
+5. Rebase upstream changes:
+<br /> `git rebase upstream/8.x` (fix any merge conflicts, and then `git rebase --continue`)
+6. Push to your fork:
+<br /> `git push origin sync-upstream`
+7. Create pull request

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ pages:
 - Technical Documentation:
     - 'Minimum Viable Product': 'mvp/mvp_doc.md'
     - 'How to build documenation': 'technical-documentation/docs-build.md'
+    - 'Syncing Drupal Project': 'technical-documentation/drupal-project.md'
     - 'Versioning Policy': 'technical-documentation/versioning.md'
 - Components:
     - 'Islandora CLAW': 'index.md'


### PR DESCRIPTION
**GitHub issue**: 

Follow-on to: https://github.com/Islandora-CLAW/drupal-project/pull/11

# What does this Pull Request do?

Adds syncing technical documentation for Drupal Project

# What's new?
Documentation
# How should this be tested?

[Build the docs locally](http://islandora-claw.github.io/CLAW/technical-documentation/docs-build/).

# Interested parties
@Islandora-CLAW/committers 
