### PR TITLE
Pinning phpcs to 2.9 for Islandora-CLAW/CLAW#618

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -8,7 +8,7 @@ $SCRIPT_DIR/travis_setup_php.sh
 echo "Install utilities needed for testing"
 mkdir /opt/utils
 cd /opt/utils
-composer require squizlabs/php_codesniffer
+composer require squizlabs/php_codesniffer ^2.9
 composer require drupal/coder
 composer require sebastian/phpcpd
 sudo ln -s /opt/utils/vendor/bin/phpcs /usr/bin/phpcs


### PR DESCRIPTION
**GitHub Issue**: Part of https://github.com/Islandora-CLAW/CLAW/issues/618

Should unblock
- https://github.com/Islandora-CLAW/islandora/pull/59
- Islandora-CLAW/islandora_collection#20
- Islandora-CLAW/islandora_image#13 

# What does this Pull Request do?

Pins phpcs to 2.9 to _hopefully_ get Travis passing again.  Or if he fails, at least it's not because of phpcs failing to execute.

# What's new?
Updated the `composer require` for phpcs to use ^2.9

# How should this be tested?

Merge and re-start the affected Travis builds.

# Interested parties
@Islandora-CLAW/committers