### PR TITLE
Using carapace in Travis build

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -34,6 +34,16 @@ until curl -s 127.0.0.1:8282; do true; done > /dev/null
 echo "Enable simpletest module"
 drush --uri=127.0.0.1:8282 en -y simpletest
 
+# Set default theme to carapace (and download dependencies, will composer-ize later)
+cd modules/contrib
+composer require "drupal/adaptivetheme:^2.0" "drupal/at_tools:^2.0" "drupal/layout_plugin:^1.0@alpha"
+drush en -y at_tools
+drush en -y layout_plugin
+mkdir /opt/drupal/web/themes/custom
+git clone https://github.com/Islandora-CLAW/carapace /var/www/html/drupal/web/themes/custom/carapace
+drush en -y carapace
+drush -y config-set system.theme default carapace
+
 echo "Setup ActiveMQ"
 cd /opt
 wget "http://archive.apache.org/dist/activemq/5.14.3/apache-activemq-5.14.3-bin.tar.gz"


### PR DESCRIPTION
**GitHub Issue**: #670

# What does this Pull Request do?

This is a short-term fix to deal with the fact that exporting blocks ties you to the theme.  Long-term we need to figure out a solution to decouple us from any particular theme.

# What's new?
Copy/paste from claw_vagrant to set up Carapace.

# How should this be tested?

After this is merged we need to re-run the tests for islandora_collection and make sure they pass.

# Interested parties
Any @Islandora-CLAW/committers feeling lucky?