### PR TITLE
Add Seth Shaw to the CLAW Committers list

### DIFF
--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -25,7 +25,7 @@ Committers share the following responsibilities:
 
 ## Committers
 
-The following is an alphabetized list of the current Islandora committers:
+The following is an alphabetized list of the current Islandora CLAW committers:
 
 | Name                        | Organization                      | irc nick    |
 |-----------------------------|-----------------------------------|-------------|
@@ -34,9 +34,16 @@ The following is an alphabetized list of the current Islandora committers:
 | Danny Lamb                  | Islandora Foundation              | dhlamb      |
 | Natkeeran Ledchumykanthan   | University of Toronto Scarborough | Natkeeran   |
 | Diego Pino                  | METRO                             | diegopino   |
-| Nick Ruest                  | York University                   | ruebot      |
 | Seth Shaw                   | University of Nevada, Las Vegas   | seth-shaw   |
 | Jared Whiklo                | University of Manitoba            | whikloj     |
+
+## Emeritus Committers
+
+The following is an alphabetized list of the prior Islandora CLAW committers:
+
+| Name                        | Organization                      | irc nick    |
+|-----------------------------|-----------------------------------|-------------|
+| Nick Ruest                  | York University                   | ruebot      |
 
 
 ## Guidelines for assessing new candidates for committership
@@ -55,7 +62,7 @@ How do we evaluate? By the interactions they have through mail. By how clear the
 
 How do we evaluate? By the interactions they have through mail. Do they help to answer questions raised on the mailing list; do they show a helpful attitude and respect for other's ideas.
 
-### Committment
+### Commitment
 
 How do we evaluate? By time, by sticking through tough issues, by helping on not-so-fun tasks as well.
 

--- a/docs/contributing/committers.md
+++ b/docs/contributing/committers.md
@@ -35,6 +35,7 @@ The following is an alphabetized list of the current Islandora committers:
 | Natkeeran Ledchumykanthan   | University of Toronto Scarborough | Natkeeran   |
 | Diego Pino                  | METRO                             | diegopino   |
 | Nick Ruest                  | York University                   | ruebot      |
+| Seth Shaw                   | University of Nevada, Las Vegas   | seth-shaw   |
 | Jared Whiklo                | University of Manitoba            | whikloj     |
 
 


### PR DESCRIPTION
* Other Relevant Links: [CLAW call agenda/minutes](https://github.com/Islandora-CLAW/CLAW/wiki/May-16,-2018#agenda)

# What does this Pull Request do?

Updates Committers document to include our latest CLAW Committer.

# What's new?

Added info on new committer Seth Shaw.

# How should this be tested?

Build the docs using mkdocs following these instructions
http://islandora-claw.github.io/CLAW/technical-documentation/docs-build/

Then see the changes locally on 
http://localhost:8111/contributing/committers/

# Additional Notes:

This is only the commit that changes the documentation content. At this time I need the help of a CLAW committer to first [install mkdocs and build the CLAW docs](http://islandora-claw.github.io/CLAW/technical-documentation/docs-build/) AND THEN run the following mkdocs command...

`mkdocs gh-deploy --clean`

This command will then deploy the documentation content to the CLAW GitHub.io Pages inside the CLAW repo's gh-pages branch. Then the CLAW GitHub.io Pages will display the new content at this URL...

http://islandora-claw.github.io/CLAW/contributing/committers/

There might be a way for a CLAW non-committer to create a PR from CLAW repo fork, but I am still sorting out the workflow. Let me know if anyone has any suggestions.

# Interested parties
@Islandora-CLAW/committers