### PR TITLE
Fixed a few small typos in the CLAW docs using aspell CLI utility

### DIFF
--- a/docs/technical-documentation/docs-build.md
+++ b/docs/technical-documentation/docs-build.md
@@ -32,6 +32,6 @@ You can preview any changes you have made to the documentation by running the fo
 
 And then visiting http://localhost:8111 in your browser.
 
-To deploy documenation to GitHub Pages, issue the following command:
+To deploy documentation to GitHub Pages, issue the following command:
 
 `mkdocs gh-deploy --clean`

--- a/docs/technical-documentation/drupal-project.md
+++ b/docs/technical-documentation/drupal-project.md
@@ -1,10 +1,10 @@
 # Introduction
 
-Islandora CLAW makes use of [drupal-project](https://github.com/drupal-composer/drupal-project), a composer template for Drupal projects. We augment it with Islandora CLAW specific changes, and need to occassionaly pull in upstream changes. The process below outlines how we will do it in a consistent manner.
+Islandora CLAW makes use of [drupal-project](https://github.com/drupal-composer/drupal-project), a composer template for Drupal projects. We augment it with Islandora CLAW specific changes, and need to occasionally pull in upstream changes. The process below outlines how we will do it in a consistent manner.
 
 # Pull in upstream changes
 
-1. Clone a fork of our fork to your or your institions GitHub organization:
+1. Clone a fork of our fork to your or your institution's GitHub organization:
 <br />  `git clone fork`
 2. Add the drupal-composer repository as a remote:
 <br /> `git remote add upstream https://github.com/drupal-composer/drupal-project.git`

--- a/docs/technical-documentation/versioning.md
+++ b/docs/technical-documentation/versioning.md
@@ -10,7 +10,7 @@ Islandora CLAW uses [semantic versioning](http://semver.org/), except for Drupal
 
 - **Major version**; Major changes, and breaks the API
 - **Minor version**; New features, and does not break the API
-- **Patch**; Bug fixes, and never breaks backward compatability
+- **Patch**; Bug fixes, and never breaks backward compatibility
 
 Example: 1.2.3
 


### PR DESCRIPTION

# What does this Pull Request do?

This commit fixes a handful of small typos.

# What's new?

No new documentation content added, just fixes typos.

# How should this be tested?

Review the diff to see if my spelling corrections are incorrect.

# Additional Notes:

I found the typos using the [aspell](https://en.wikipedia.org/wiki/GNU_Aspell) CLI spell checker.

# Interested parties
@Islandora-CLAW/committers