### PR TITLE
Remove claw_vagrant, fix typo, link install to claw-playbook.

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,1 +1,1 @@
-../../claw_vagrant/README.md
+../../claw_playbook/README.md

--- a/docs/technical-documentation/versioning.md
+++ b/docs/technical-documentation/versioning.md
@@ -17,7 +17,6 @@ Example: 1.2.3
 * [Alpaca](https://github.com/Islandora-CLAW/alpaca)
 * [Chullo](https://islandora-claw.github.io/CLAW/chullo)
 * [CLAW](https://github.com/Islandora-CLAW/CLAW)
-* [claw_vagrant](https://github.com/Islandora-CLAW/claw_vagrant)
 * [Crayfish](https://islandora-claw.github.io/CLAW/Crayfish)
 * [Crayfish Commons](https://islandora-claw.github.io/CLAW/Crayfish-Commons)
 * [Syn](https://github.com/Islandora-CLAW/Syn)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ pages:
     - 'Versioning Policy': 'technical-documentation/versioning.md'
     - 'Alpaca Technical Stack': 'alpaca/alpaca-technical-stack.md'
     - 'RDF Mapping': 'islandora/rdf-mapping.md'
-    - 'Dupal Bundle Configurations': 'islandora/drupal-bundle-configurations.md'
+    - 'Drupal Bundle Configurations': 'islandora/drupal-bundle-configurations.md'
 - Components:
     - 'Islandora CLAW': 'index.md'
     - 'Alpaca': 'alpaca/README.md'


### PR DESCRIPTION
A couple small fixes.

* Make the install link point to claw-playbook now that claw_vagrant is removed
* Fix a typo
* Remove reference to claw_vagant in versioning documents

@Islandora-CLAW/committers