### PR TITLE
Calling drupal-scaffold command to accomodate lockfile

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -21,8 +21,10 @@ cd /opt
 git clone https://github.com/Islandora-CLAW/drupal-project.git drupal
 cd drupal
 if [ -n "$COMPOSER_PATH" ]; then
+  composer drupal-scaffold
   composer install
 else
+  php -dmemory_limit=-1 $COMPOSER_PATH drupal-scaffold
   php -dmemory_limit=-1 $COMPOSER_PATH install
 fi
 


### PR DESCRIPTION
This is to get tests passing for https://github.com/Islandora-CLAW/islandora/pull/86

# What does this Pull Request do?

Uses `composer drupal-scaffold` before `composer install` to work with the lockfile we're now providing.

# How should this be tested?

Travis won't die with an OOM error on https://github.com/Islandora-CLAW/islandora/pull/86 once is merged (I HOPE).

# Interested parties
@Islandora-CLAW/committers, @whikloj in particular