### PR TITLE
Inverted test

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -21,9 +21,11 @@ cd /opt
 git clone https://github.com/Islandora-CLAW/drupal-project.git drupal
 cd drupal
 if [ -z "$COMPOSER_PATH" ]; then
-  composer update
+  composer install
+  composer drupal-scaffold
 else
-  php -dmemory_limit=-1 $COMPOSER_PATH update
+  php -dmemory_limit=-1 $COMPOSER_PATH install
+  php -dmemory_limit=-1 $COMPOSER_PATH drupal-scaffold
 fi
 
 echo "Setup Drush"

--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -20,12 +20,10 @@ echo "Composer install drupal site"
 cd /opt
 git clone https://github.com/Islandora-CLAW/drupal-project.git drupal
 cd drupal
-if [ -n "$COMPOSER_PATH" ]; then
-  composer drupal-scaffold
-  composer install
+if [ -z "$COMPOSER_PATH" ]; then
+  composer update
 else
-  php -dmemory_limit=-1 $COMPOSER_PATH drupal-scaffold
-  php -dmemory_limit=-1 $COMPOSER_PATH install
+  php -dmemory_limit=-1 $COMPOSER_PATH update
 fi
 
 echo "Setup Drush"


### PR DESCRIPTION
I was wrong, so the `-n` test meant to test if there **is** a value. So if `$COMPOSER_PATH` has a value then **don't** use it. 

So I was wrong, `-z` checks for an empty value.

Also, `composer drupal-scaffold` doesn't work until you run `composer update`.

This should get us past the original memory outage to a new one which is [this one](https://getcomposer.org/doc/articles/troubleshooting.md#proc-open-fork-failed-errors)

Based on my test there is swap defined so I'm not sure what we can do.

@Islandora-CLAW/committers especially @dannylamb 