### PR TITLE
Linking to project documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For more details, please check out the following resources:
   * [2017](https://github.com/Islandora-CLAW/CLAW/wiki/2017)
   * [2018](https://github.com/Islandora-CLAW/CLAW/wiki/2018)
 
+* [Documentation](https://islandora-claw.github.io/CLAW/)
 * [Contributing](https://github.com/Islandora-CLAW/CLAW/blob/master/CONTRIBUTING.md)
 
 ## Repository Structure


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/883

# What does this Pull Request do?

Links to the docs in the readme

# Interested parties
@Islandora-CLAW/committers