### PR TITLE
Letting drupal/coder dictate the version of coder_sniffer

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -7,11 +7,9 @@ echo "Install utilities needed for testing"
 mkdir /opt/utils
 cd /opt/utils
 if [ -z "$COMPOSER_PATH" ]; then
-  composer require squizlabs/php_codesniffer ^2.9
   composer require drupal/coder
   composer require sebastian/phpcpd
 else
-  php -dmemory_limit=-1 $COMPOSER_PATH require squizlabs/php_codesniffer ^2.9
   php -dmemory_limit=-1 $COMPOSER_PATH require drupal/coder
   php -dmemory_limit=-1 $COMPOSER_PATH require sebastian/phpcpd
 fi


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/931

Unblocks: https://github.com/Islandora-CLAW/islandora/pull/99
# What does this Pull Request do?

Removes code that was manually installing and old version (^2.9) of `coder_sniffer`, which is now in conflict with what is supported by `drupal/coder` (^3.0).

# What's new?
Getting rid of a call to composer to install `coder_sniffer`, so that `drupal/coder` can pull in the version it needs transitively.

# How should this be tested?

Can't, but once merged, Travis should stop blowing up on `phpcs` calls.

# Interested parties
@Islandora-CLAW/committers @MarcusBarnes 