### PR TITLE
Stop calling drupal-scaffold

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -24,10 +24,8 @@ git clone https://github.com/Islandora-CLAW/drupal-project.git drupal
 cd drupal
 if [ -z "$COMPOSER_PATH" ]; then
   composer install
-  composer drupal-scaffold
 else
   php -dmemory_limit=-1 $COMPOSER_PATH install
-  php -dmemory_limit=-1 $COMPOSER_PATH drupal-scaffold
 fi
 
 echo "Setup Drush"


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/955

Also noted here: https://github.com/Islandora-CLAW/islandora_demo/pull/15#issuecomment-455643935

# What does this Pull Request do?

Removes calls to `drupal-scaffold` as it has been changed to `drupal:scaffold` and is called automatically

# What's new?

Deleted 2 lines

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

This script is used by Travis, so checking that the `travis_install_drupal.sh` script doesn't cause this message should be enough. https://github.com/Islandora-CLAW/islandora_demo/pull/15#issuecomment-455643935

# Interested parties
@Islandora-CLAW/committers