### PR TITLE
Updating travis provisioner for pdf.js

### DIFF
--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -55,6 +55,20 @@ git clone https://github.com/Islandora-CLAW/carapace /opt/drupal/web/themes/cust
 drush then -y carapace
 drush -y config-set system.theme default carapace
 
+mkdir libraries
+cd libraries
+wget "https://github.com/mozilla/pdf.js/releases/download/v2.0.943/pdfjs-2.0.943-dist.zip"
+unzip pdfjs-2.0.943-dist.zip pdf.js
+rm pdfjs-2.0.943-dist.zip
+
+# Get the pdf module
+if [ -z "$COMPOSER_PATH" ]; then
+  composer require "drupal/pdf:1.x-dev"
+else
+  php -dmemory_limit=-1 $COMPOSER_PATH require "drupal/pdf:1.x-dev"
+fi
+drush -y en pdf
+
 echo "Setup ActiveMQ"
 cd /opt
 wget "http://archive.apache.org/dist/activemq/5.14.3/apache-activemq-5.14.3-bin.tar.gz"

--- a/.scripts/travis_setup_drupal.sh
+++ b/.scripts/travis_setup_drupal.sh
@@ -58,7 +58,8 @@ drush -y config-set system.theme default carapace
 mkdir libraries
 cd libraries
 wget "https://github.com/mozilla/pdf.js/releases/download/v2.0.943/pdfjs-2.0.943-dist.zip"
-unzip pdfjs-2.0.943-dist.zip pdf.js
+mkdir pdf.js
+unzip pdfjs-2.0.943-dist.zip -d pdf.js
 rm pdfjs-2.0.943-dist.zip
 
 # Get the pdf module


### PR DESCRIPTION
**GitHub Issue**: Goes with https://github.com/Islandora-CLAW/islandora_demo/pull/16

# What does this Pull Request do?

Updates the travis script that provisions drupal to pull in the pdf.js library

# What's new?
Some shot in the dark bash changes.  Downloads and unzips the pdf.js javascript library and `composer require`s and `drush en`s the `pdf` contrib module.

# How should this be tested?

Not entirely sure.  This has to get merged before we can restart the build on https://github.com/Islandora-CLAW/islandora_demo/pull/16

This will most likely require some iteration (unless I'm unwittingly a bash master)

# Interested parties
@Islandora-CLAW/committers, specifically @Natkeeran 