### PR TITLE
Issue 887

### DIFF
--- a/docs/technical-documentation/adding_format_jsonld.md
+++ b/docs/technical-documentation/adding_format_jsonld.md
@@ -1,0 +1,17 @@
+By default, Islandora deploys with the `jsonld` module and `Milliner` microservice set to strip Drupal's Symfony-style
+`_format` query parameter.  This means that when your content is indexed in Fedora, the triplestore, etc... it's URI will
+be something like `http://localhost:8000/node/1` and not `http://localhost:8000/node/1?_format=jsonld`.
+
+If you are using a __very__ early version of Islandora 8 (pre-release), then you may have uris with `_format=jsonld` at the
+end of them.  If you update to newer code, you will need to ensure that your site is configured to add `?_format=jsonld`
+back to the urls if you want to maintain consistency.
+
+- Go to `admin/config/search/jsonld` and confirm the 'Remove jsonld parameter from @ids' checkbox is unchecked.
+- Add `strip_format_jsonld: false` to `/var/www/html/Crayfish/Milliner/cfg/config.yaml`
+
+If you are using claw-playbook and are provisioning new environments for your older Islandora 8, you'll want to lock down the
+variables in your inventory that control this config.
+
+- `crayfish_milliner_strip_format_jsonld: true`
+- `webserver_app_jsonld: yes`
+- `webserver_app_jsonld_remove_format: 1`

--- a/docs/technical-documentation/adding_format_jsonld.md
+++ b/docs/technical-documentation/adding_format_jsonld.md
@@ -13,5 +13,4 @@ If you are using claw-playbook and are provisioning new environments for your ol
 variables in your inventory that control this config.
 
 - `crayfish_milliner_strip_format_jsonld: true`
-- `webserver_app_jsonld: yes`
 - `webserver_app_jsonld_remove_format: 1`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ extra:
     - type: 'twitter'
       link: 'https://twitter.com/islandora'
 
-nav:
+pages:
   - Summary: 'index.md'
   - Installation: 'installation.md'
   - User Documentation:
@@ -41,22 +41,23 @@ nav:
       - 'Users': 'user-documentation/users.md'
       - 'Blocks': 'user-documentation/placing-blocks.md'
       - 'Usage Stats': 'user-documentation/usage-stats.md'
-      - 'Multilingual': 'user-documentation/multilingual.md'      
-  - REST Documentation:
+      - 'Multilingual': 'user-documentation/multilingual.md'
+  - Developer Documentation:
+    - REST Documentation:
       - 'Introduction': 'technical-documentation/using-rest-endpoints.md'
       - 'GET': 'technical-documentation/rest-get.md'
       - 'POST/PUT': 'technical-documentation/rest-create.md'
       - 'PATCH': 'technical-documentation/rest-patch.md'
       - 'DELETE': 'technical-documentation/rest-delete.md'
       - 'Signposting': 'technical-documentation/rest-signposting.md'
-  - Developer Documentation:
-      - 'Installing Modules': 'technical-documentation/install-enable-drupal-modules.md'
-      - 'Running Tests': 'technical-documentation/running-automated-tests.md'
-      - 'Flysystem': 'technical-documentation/flysystem.md'
-      - 'Versioning Policy': 'technical-documentation/versioning.md'
-      - 'Documentation Style Guide': 'technical-documentation/docs_style_guide.md'
-      - 'How to Build Documentation': 'technical-documentation/docs-build.md'
-      - 'Testing Notes': 'technical-documentation/testing-notes.md'
+    - 'Installing Modules': 'technical-documentation/install-enable-drupal-modules.md'
+    - 'Running Tests': 'technical-documentation/running-automated-tests.md'
+    - 'Flysystem': 'technical-documentation/flysystem.md'
+    - 'Versioning Policy': 'technical-documentation/versioning.md'
+    - 'Documentation Style Guide': 'technical-documentation/docs_style_guide.md'
+    - 'How to Build Documentation': 'technical-documentation/docs-build.md'
+    - 'Testing Notes': 'technical-documentation/testing-notes.md'
+    - 'Adding back ?_format=jsonld': 'technical-documentation/adding_format_jsonld.md'
   - Migration:
       - 'CSV': 'technical-documentation/migrate-csv.md'
       - 'Islandora 7': 'technical-documentation/migrate-7x.md'


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/887

# What does this Pull Request do?

Documents the configuration around `jsonld` and `Milliner` needed to add `?_format=jsonld` back into the urls if you really need it.

Also, nested the REST documentation as per some @mjordan feed back a while ago.

# What's new?

A page in Technical Documentation titled "Adding Back In ?_format=jsonld"

# How should this be tested?

- Pull in this PR
- `mkdocs build --clean`
- `mkdocs serve`
- Go to localhost:8111 to view the documentation
- In the sidebar on the left, click "Technical Documentation", and then "Adding Back In ?_format=jsonld"
- Read it and let me know

# Interested parties
@Islandora-CLAW/committers
