### PR TITLE
Update mkdocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,16 @@ site_description: Documentation for Islandora CLAW
 dev_addr: 'localhost:8111'
 repo_url: https://github.com/Islandora-CLAW/CLAW
 
-theme: material
+theme:
+  name: 'material'
+  palette:
+    primary: 'red'
+    accent: 'red'
+  font:
+    text: 'Roboto'
+    code: 'Roboto Mono'
+  logo: 'assets/claw.png'
+  language: 'en'
 markdown_extensions:
   - admonition
 


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?

If you have an older version of mkdocs, then the current configuration works great. If you have a newer one (> 1.0) then you get the default colours (blue), fonts, and logos.

This updates the configuration, you should pull it down and test build it locally (`mkdocs serve`) to see that it appears the same as the one online https://islandora-claw.github.io/CLAW/

# How should this be tested?

Build locally and see that same as online (above)

# Interested parties
@Islandora-CLAW/committers @rosiel 
